### PR TITLE
Adding support for MacOS

### DIFF
--- a/src/QueryProcessor.cpp
+++ b/src/QueryProcessor.cpp
@@ -1,19 +1,19 @@
 #include "QueryProcessor.h"
 #include <immintrin.h>
-
 #include <emmintrin.h>
 #include <string.h>
-
 #include <sys/time.h>
-#include <stdio.h>
 #include <string.h>
+#if defined(__MACH__)
 #include <stdlib.h>
+#else 
+#include <malloc.h>
+#endif
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <pthread.h>
-#include <malloc.h>
+
 #include <sys/time.h>
 #include <sys/file.h>
 #include <unistd.h>

--- a/src/RecordLoader.h
+++ b/src/RecordLoader.h
@@ -1,12 +1,14 @@
 #ifndef _RECORDLOADER_H
 #define _RECORDLOADER_H
-
 #include <stdio.h>
+#if defined(__MACH__)
 #include <stdlib.h>
+#else 
+#include <malloc.h>
+#endif
 #include <string.h>
 #include <ctype.h>
 #include <pthread.h>
-#include <malloc.h>
 #include <sys/time.h>
 #include <sys/file.h>
 #include <unistd.h>


### PR DESCRIPTION
- Extending support for the project to MacOS by handling the following issue: https://github.com/RIOT-OS/RIOT/issues/2361
- Conditional including Malloc.h library since deprecated and replaced with stdlib.h.